### PR TITLE
Fixed game updates always running for (almost) every game

### DIFF
--- a/source/LibraryManagement.cs
+++ b/source/LibraryManagement.cs
@@ -384,6 +384,9 @@ namespace LibraryManagement
                     Common.LogError(ex, false, true, "LibraryManagement");
                 }
             }
+
+            PluginSettings.Settings.LastAutoLibUpdateAssetsDownload = DateTime.Now;
+            SavePluginSettings(PluginSettings.Settings);
         }
 
 

--- a/source/LibraryManagement.csproj
+++ b/source/LibraryManagement.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugDevel9|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>..\..\..\Dropbox\Playnite\Playnite9\Extensions\playnite-librarymanagement-plugin\</OutputPath>
+    <OutputPath>bin\DebugDevel9</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -41,7 +41,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="akr.WPF.Controls.ColorPicker">
-      <HintPath>..\..\playnite-howlongtobeat-plugin\source\playnite-plugincommon\CommonPluginsResources\Resources\akr.WPF.Controls.ColorPicker.dll</HintPath>
+      <HintPath>playnite-plugincommon\CommonPluginsResources\Resources\akr.WPF.Controls.ColorPicker.dll</HintPath>
     </Reference>
     <Reference Include="AngleSharp, Version=0.9.9.0, Culture=neutral, PublicKeyToken=e83494dcdc6d31ea, processorArchitecture=MSIL">
       <HintPath>packages\AngleSharp.0.9.9\lib\net45\AngleSharp.dll</HintPath>
@@ -716,6 +716,6 @@
   <Import Project="playnite-plugincommon\CommonPluginsShared\CommonPluginsShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell -ExecutionPolicy Unrestricted $(SolutionDir)..\build\build.ps1 -ConfigurationName $(ConfigurationName) -OutDir $(SolutionDir)$(OutDir) -SolutionDir $(SolutionDir)</PostBuildEvent>
+    <!-- <PostBuildEvent>powershell -ExecutionPolicy Unrestricted $(SolutionDir)..\build\build.ps1 -ConfigurationName $(ConfigurationName) -OutDir $(SolutionDir)$(OutDir) -SolutionDir $(SolutionDir)</PostBuildEvent> -->
   </PropertyGroup>
 </Project>

--- a/source/LibraryManagement.csproj
+++ b/source/LibraryManagement.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugDevel9|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\DebugDevel9</OutputPath>
+    <OutputPath>..\..\..\Dropbox\Playnite\Playnite9\Extensions\playnite-librarymanagement-plugin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -716,6 +716,6 @@
   <Import Project="playnite-plugincommon\CommonPluginsShared\CommonPluginsShared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <!-- <PostBuildEvent>powershell -ExecutionPolicy Unrestricted $(SolutionDir)..\build\build.ps1 -ConfigurationName $(ConfigurationName) -OutDir $(SolutionDir)$(OutDir) -SolutionDir $(SolutionDir)</PostBuildEvent> -->
+    <PostBuildEvent>powershell -ExecutionPolicy Unrestricted $(SolutionDir)..\build\build.ps1 -ConfigurationName $(ConfigurationName) -OutDir $(SolutionDir)$(OutDir) -SolutionDir $(SolutionDir)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/source/Services/LibraryManagementTools.cs
+++ b/source/Services/LibraryManagementTools.cs
@@ -70,15 +70,10 @@ namespace LibraryManagement.Services
 
                     CheckGenre();
 
-                    // Remplace genres
-                    IEnumerable<Game> PlayniteDb = PlayniteApi.Database.Games.Where(x => x.Hidden == true || x.Hidden == false);
-                    if (OnlyToDay)
-                    {
-                        PlayniteDb = PlayniteApi.Database.Games
-                            .Where(x => x.Added != null && x.Added > PluginSettings.LastAutoLibUpdateAssetsDownload);
-                    }
+                    // Replace genres
+                    var PlayniteDb = GetGamesToUpdate(OnlyToDay);
 
-                    activateGlobalProgress.ProgressMaxValue = (double)PlayniteDb.Count();
+                    activateGlobalProgress.ProgressMaxValue = PlayniteDb.Count;
 
                     string CancelText = string.Empty;
                     List<Game> gamesUpdated = new List<Game>();
@@ -263,15 +258,10 @@ namespace LibraryManagement.Services
 
                     CheckFeature();
 
-                    // Remplace features
-                    IEnumerable<Game> PlayniteDb = PlayniteApi.Database.Games.Where(x => x.Hidden == true || x.Hidden == false);
-                    if (OnlyToDay)
-                    {
-                        PlayniteDb = PlayniteApi.Database.Games
-                            .Where(x => x.Added != null && x.Added > PluginSettings.LastAutoLibUpdateAssetsDownload);
-                    }
+                    // Replace features
+                    var PlayniteDb = GetGamesToUpdate(OnlyToDay);
 
-                    activateGlobalProgress.ProgressMaxValue = (double)PlayniteDb.Count();
+                    activateGlobalProgress.ProgressMaxValue = PlayniteDb.Count;
 
                     string CancelText = string.Empty;
                     List<Game> gamesUpdated = new List<Game>();
@@ -464,15 +454,10 @@ namespace LibraryManagement.Services
 
                     CheckTags();
 
-                    // Remplace tags
-                    IEnumerable<Game> PlayniteDb = PlayniteApi.Database.Games.Where(x => x.Hidden == true || x.Hidden == false);
-                    if (OnlyToDay)
-                    {
-                        PlayniteDb = PlayniteApi.Database.Games
-                            .Where(x => x.Added != null && x.Added > PluginSettings.LastAutoLibUpdateAssetsDownload);
-                    }
+                    // Replace tags
+                    var PlayniteDb = GetGamesToUpdate(OnlyToDay);
 
-                    activateGlobalProgress.ProgressMaxValue = (double)PlayniteDb.Count();
+                    activateGlobalProgress.ProgressMaxValue = PlayniteDb.Count;
 
                     string CancelText = string.Empty;
                     List<Game> gamesUpdated = new List<Game>();
@@ -658,15 +643,10 @@ namespace LibraryManagement.Services
 
                     CheckCompanies();
 
-                    // Remplace Companies
-                    IEnumerable<Game> PlayniteDb = PlayniteApi.Database.Games.Where(x => x.Hidden == true || x.Hidden == false);
-                    if (OnlyToDay)
-                    {
-                        PlayniteDb = PlayniteApi.Database.Games
-                            .Where(x => x.Added != null && x.Added > PluginSettings.LastAutoLibUpdateAssetsDownload);
-                    }
+                    // Replace Companies
+                    var PlayniteDb = GetGamesToUpdate(OnlyToDay);
 
-                    activateGlobalProgress.ProgressMaxValue = (double)PlayniteDb.Count();
+                    activateGlobalProgress.ProgressMaxValue = PlayniteDb.Count;
 
                     string CancelText = string.Empty;
                     List<Game> gamesUpdated = new List<Game>();
@@ -881,14 +861,9 @@ namespace LibraryManagement.Services
                     Stopwatch stopWatch = new Stopwatch();
                     stopWatch.Start();
 
-                    IEnumerable<Game> PlayniteDb = PlayniteApi.Database.Games.Where(x => x.Hidden == true || x.Hidden == false);
-                    if (OnlyToDay)
-                    {
-                        PlayniteDb = PlayniteApi.Database.Games
-                            .Where(x => x.Added != null && x.Added > PluginSettings.LastAutoLibUpdateAssetsDownload);
-                    }
+                    var PlayniteDb = GetGamesToUpdate(OnlyToDay);
 
-                    activateGlobalProgress.ProgressMaxValue = (double)PlayniteDb.Count();
+                    activateGlobalProgress.ProgressMaxValue = PlayniteDb.Count;
 
                     string CancelText = string.Empty;
                     List<Game> gamesUpdated = new List<Game>();
@@ -1008,14 +983,9 @@ namespace LibraryManagement.Services
                     Stopwatch stopWatch = new Stopwatch();
                     stopWatch.Start();
 
-                    IEnumerable<Game> PlayniteDb = PlayniteApi.Database.Games.Where(x => x.Hidden == true || x.Hidden == false);
-                    if (OnlyToDay)
-                    {
-                        PlayniteDb = PlayniteApi.Database.Games
-                            .Where(x => x.Added != null && x.Added > PluginSettings.LastAutoLibUpdateAssetsDownload);
-                    }
+                    var PlayniteDb = GetGamesToUpdate(OnlyToDay);
 
-                    activateGlobalProgress.ProgressMaxValue = (double)PlayniteDb.Count();
+                    activateGlobalProgress.ProgressMaxValue = PlayniteDb.Count;
 
                     string CancelText = string.Empty;
                     List<Game> gamesUpdated = new List<Game>();
@@ -1127,14 +1097,9 @@ namespace LibraryManagement.Services
                     Stopwatch stopWatch = new Stopwatch();
                     stopWatch.Start();
 
-                    IEnumerable<Game> PlayniteDb = PlayniteApi.Database.Games.Where(x => x.Hidden == true || x.Hidden == false);
-                    if (OnlyToDay)
-                    {
-                        PlayniteDb = PlayniteApi.Database.Games
-                            .Where(x => x.Added != null && x.Added > PluginSettings.LastAutoLibUpdateAssetsDownload);
-                    }
+                    var PlayniteDb = GetGamesToUpdate(OnlyToDay);
 
-                    activateGlobalProgress.ProgressMaxValue = (double)PlayniteDb.Count();
+                    activateGlobalProgress.ProgressMaxValue = PlayniteDb.Count;
 
                     string CancelText = string.Empty;
                     List<Game> gamesUpdated = new List<Game>();
@@ -1217,5 +1182,13 @@ namespace LibraryManagement.Services
             return IsUpdated;
         }
         #endregion
+
+        private ICollection<Game> GetGamesToUpdate(bool onlyRecentlyUpdated)
+        {
+            if (onlyRecentlyUpdated)
+                return PlayniteApi.Database.Games.Where(g => g.Added > PluginSettings.LastAutoLibUpdateAssetsDownload || g.Modified > PluginSettings.LastAutoLibUpdateAssetsDownload).ToList();
+            else
+                return PlayniteApi.Database.Games;
+        }
     }
 }


### PR DESCRIPTION
In the existing release of LibraryManagement, `Settings.LastAutoLibUpdateAssetsDownload` is only set the very first time the plugin settings are saved. This fixes that so that it's updated every `AutoUpdate` call, resulting in only a few games being processed rather than most of your library (if you installed the plugin long ago). This makes the runtime several dozens/hundreds of times faster after library imports.