### PR TITLE
Improve English error messages

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -1,30 +1,30 @@
 param(
-	[string]$ConfigurationName, 
+	[string]$ConfigurationName,
 	[string]$OutDir,
-	[string]$SolutionDir 
+	[string]$SolutionDir
 )
 
 
 $PlaynitePathTEMP = "C:\Playnite_dev"
-if (Test-Path -Path $PlaynitePathTEMP) 
+if (Test-Path -Path $PlaynitePathTEMP)
 {
 	$PlaynitePath = $PlaynitePathTEMP
 }
 
 $PlaynitePathTEMP = "D:\Playnite_dev"
-if (Test-Path -Path $PlaynitePathTEMP) 
+if (Test-Path -Path $PlaynitePathTEMP)
 {
 	$PlaynitePath = $PlaynitePathTEMP
 }
 
 $PlaynitePathTEMP = "G:\Playnite_dev"
-if (Test-Path -Path $PlaynitePathTEMP) 
+if (Test-Path -Path $PlaynitePathTEMP)
 {
 	$PlaynitePath = $PlaynitePathTEMP
 }
 
 $PlaynitePathTEMP = "F:\Playnite_dev"
-if (Test-Path -Path $PlaynitePathTEMP) 
+if (Test-Path -Path $PlaynitePathTEMP)
 {
 	$PlaynitePath = $PlaynitePathTEMP
 }
@@ -34,10 +34,10 @@ $ToolboxPath = (Join-Path $PlaynitePath "toolbox.exe")
 $OutDirPath = (Join-Path $OutDir "..")
 
 
-if ($ConfigurationName -eq "release") 
+if ($ConfigurationName -eq "release")
 {
 	$Version = ""
-	foreach($Line in Get-Content (Join-Path $SolutionDir  "extension.yaml")) 
+	foreach($Line in Get-Content (Join-Path $SolutionDir  "extension.yaml"))
 	{
 		if($Line -imatch "Version:")
 		{
@@ -55,24 +55,24 @@ if ($ConfigurationName -eq "release")
 		if (Test-Path $ToolboxPath)
 		{
 			& $ToolboxPath "pack" $OutDir $OutDirPath
-		
+
 			$Result = & $ToolboxPath "verify" "installer" $Manifest
 			if($Result -imatch "Installer manifest passed verification")
-			{		
-				
+			{
+
 			}
-			else 
+			else
 			{
 				echo $Result
-			}		
+			}
 		}
-		else 
+		else
 		{
-			echo "toolbox.exe not find."
-		}	
+			echo "toolbox.exe is missing."
+		}
 	}
 	else
 	{
-		echo "Manifest not contains actual version"
+		echo "Manifest is missing current version."
 	}
 }


### PR DESCRIPTION
I think it's better to use the word missing for both error cases.

In the first case the "toolbox.exe wasn't found" which is the same as "toolbox.exe is missing".
I chose the second variant to not use special characters.

Second case is similar to the first one. The current version which is present in the addon manifest is missing in the installer manifest.

The removal of space characters shouldn't change the build file in any sense.